### PR TITLE
Fixed: Output in Simra ordering

### DIFF
--- a/wrf2simra/__init__.py
+++ b/wrf2simra/__init__.py
@@ -75,19 +75,13 @@ class WRFConverter:
 
             W = vtk_to_numpy(new_fields.GetPointData().GetArray('WIND'))
 
-            nx = outputGrid.GetDimensions()[0]
-            ny = outputGrid.GetDimensions()[1]
-            nz = outputGrid.GetDimensions()[2]
+            # Simra numbering has i, j swapped (col major) but k still
+            # running fastest (as if row major)
+            nx, ny, nz = outputGrid.GetDimensions()
+            W = W.reshape(nx, ny, nz, -1).transpose(1, 0, 2, 3).reshape(-1, 3)
 
-            W2 = np.zeros(W.shape)
-            for i in range(0, nx):
-                for j in range(0, ny):
-                    for k in range(0, nz):
-                        vtkIdx = i + (j + k * ny) * nx
-                        simraIdx = k + (i + j * nx) * nz
-                        W2[simraIdx,:] = W[vtkIdx,:]
             z = np.zeros((W.shape[0], 8))
-            W = np.hstack([W2, z])
+            W = np.hstack([W, z])
             strat = np.float32(np.zeros((W.shape[0], 1)))
 
             ftype = np.dtype(f'<f4')


### PR DESCRIPTION
VTK arrays are (to the best of my knowledge) simply row major. So the original:

    vtkIdx = i + (j + k * ny) * nx

which corresponds to a column major array, should be:

    vtkIdx = k + (j + i * ny) * nz

The simra arrays are row major for (i,j) vs. k but column major as far as i vs. j is concerned. In effect that only means i and j are swapped vis-a-vis VTK ordering. So this is correct:

    simraIdx = k + (i * j * nx) * nz

Compare with the correct version of `vtkIdx` above and swap i <-> j and nx <-> ny.

This commit rewrites the transposition logic as an idiomatic numpy call:

    .transpose(1, 0, 2, 3)

which means to keep axes 2 and 3 and just swap axes 0 and 1.